### PR TITLE
Correct both positive and negative time drift

### DIFF
--- a/proliphix/proliphix.py
+++ b/proliphix/proliphix.py
@@ -116,7 +116,7 @@ class PDP(object):
         self._data['ActualTime'] = now
         drift = self._data['ActualTime'] - int(self._data['Time'])
 
-        if drift > 60:
+        if abs(drift) > 60:
             logger.warning("PDP time drifted by %d seconds, resetting" % drift)
             self._set(Time=set_now)
 


### PR DESCRIPTION
I noticed the time on my Proliphix thermostat did not always get corrected properly and found a small bug.
The original code only corrects the time when there is positive dift. I corrected it so that it corrects the time when there is negative drift as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/proliphix/4)
<!-- Reviewable:end -->
