### PR TITLE
Add features to support Home Assistant integration

### DIFF
--- a/tests/test_proliphix.py
+++ b/tests/test_proliphix.py
@@ -40,9 +40,10 @@ class TestProliphix(unittest.TestCase):
         rp.assert_called_once_with(
             "http://%s/get" % mock.sentinel.host,
             auth=(mock.sentinel.user, mock.sentinel.passwd),
-            data=('OID1.10.9=&OID1.2=&OID2.5.1=&OID2.7.1=&OID4.1.1=&OID4.1.11='
+            data=('OID1.10.9=&OID1.2=&OID1.8=&OID2.5.1=&OID2.7.1='
+                  '&OID4.1.1=&OID4.1.11='
                   '&OID4.1.13=&OID4.1.14='
-                  '&OID4.1.2=&OID4.1.4=&OID4.1.5='
+                  '&OID4.1.2=&OID4.1.3=&OID4.1.4=&OID4.1.5='
                   '&OID4.1.6=&OID4.5.1=&OID4.5.3=&OID4.5.5=&OID4.5.6=')
             )
 


### PR DESCRIPTION
As stated in the proliphix.py file, this adds a few new properties to the class to expose some additional OID's of the device to the user.  These features are intended to provide the minimum functionality needed to integrate a Proliphix thermostat as a fully-functioning Climate device within Home Assistant.

I did NOT make any changes to version numbers.  I figured I'd leave that to you if you accept the changes.

Also, the changes are 100% additions to the existing code base.  None of the existing code was changed or removed, so there will be no issues with backward-compatibility.

It is my hope that these enhancements will ultimately end up on the PyPI.org respository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/proliphix/6)
<!-- Reviewable:end -->
